### PR TITLE
fixes deprecated get_feature_names

### DIFF
--- a/pyLDAvis/sklearn.py
+++ b/pyLDAvis/sklearn.py
@@ -17,7 +17,7 @@ def _get_term_freqs(dtm):
 
 
 def _get_vocab(vectorizer):
-    return vectorizer.get_feature_names()
+    return vectorizer.get_feature_names_out()
 
 
 def _row_norm(dists):


### PR DESCRIPTION
This commit fixes, AttributeError: 'CountVectorizer' object has no attribute 'get_feature_names'.